### PR TITLE
Add www to va.gov link

### DIFF
--- a/app/views/va_common/_footer.html.erb
+++ b/app/views/va_common/_footer.html.erb
@@ -63,7 +63,7 @@
 
     <div class="large-8 columns">
       <ul class="final-list">
-        <li><a target="_blank" href="http://va.gov/">VA.gov</a></li>
+        <li><a target="_blank" href="http://www.va.gov/">VA.gov</a></li>
         <li><a target="_blank" href="http://www.va.gov/oig/">Inspector General</a></li>
         <li><a target="_blank" href="http://www.section508.va.gov/">Accessibility</a></li>
         <li><a target="_blank" href="http://www.va.gov/privacy/">Privacy</a></li>


### PR DESCRIPTION
Seems like people on the VA network get an error when www is not included in front of va.gov.
