### PR TITLE
Remove VEC TM

### DIFF
--- a/app/views/va_common/_footer.html.erb
+++ b/app/views/va_common/_footer.html.erb
@@ -19,7 +19,7 @@
     <div class="small-12 medium-3 columns">
       <dl class="va-list--linkgroup">
         <dt class="va-list--linkgroup-title">Resources</dt>
-        <dd><a href="/veterans-employment-center/">Veterans Employment Center</a></dd>
+        <dd><a href="/employment/">Veterans Employment Center</a></dd>
         <dd><a href="/facility-locator">Facility Locator</a></dd>
         <dd><a href="/gi-bill-comparison-tool/">GI Bill Comparison Tool</a></dd>
       </dl>

--- a/app/views/va_common/_footer.html.erb
+++ b/app/views/va_common/_footer.html.erb
@@ -19,7 +19,7 @@
     <div class="small-12 medium-3 columns">
       <dl class="va-list--linkgroup">
         <dt class="va-list--linkgroup-title">Resources</dt>
-        <dd><a href="/veterans-employment-center/">Veterans Employment Center&trade;</a></dd>
+        <dd><a href="/veterans-employment-center/">Veterans Employment Center</a></dd>
         <dd><a href="/facility-locator">Facility Locator</a></dd>
         <dd><a href="/gi-bill-comparison-tool/">GI Bill Comparison Tool</a></dd>
       </dl>


### PR DESCRIPTION
Removing TM from vets.gov footer, as we only need the trademark symbol in one place on the site and it is already located at https://www.vets.gov/employment/

Agreed to by the content team in a parallel change here: https://github.com/department-of-veterans-affairs/vets-website/pull/2551
